### PR TITLE
Add requirements.txt and improve dependency documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,31 @@ Before using DiffStaticAnalyzer, ensure that [CodeQL](https://codeql.github.com/
 
    You should see the installed CodeQL version.
 
+5. **Install 7-Zip:**
+   This tool uses 7-Zip (7z) to extract npm package files. It's not installed by default on macOS or most Linux distributions.
+
+   - On macOS, install it using Homebrew:
+     ```bash
+     brew install p7zip
+     ```
+
+   - On Linux (Debian/Ubuntu):
+     ```bash
+     sudo apt-get install p7zip-full
+     ```
+
+   - On Linux (Fedora/RHEL/CentOS):
+     ```bash
+     sudo dnf install p7zip p7zip-plugins
+     ```
+
+   - On Windows, download and install from the [7-Zip website](https://www.7-zip.org/download.html).
+
+   Verify the installation by running:
+   ```bash
+   7z --help
+   ```
+
 Now you're ready to use DiffStaticAnalyzer with the CodeQL CLI for npm package analysis.
 
 ## Installation
@@ -47,6 +72,12 @@ No installation is required. Simply clone this repository to your local machine.
 
 ```bash
 git clone https://github.com/your-repo/diff-static-analyzer.git
+```
+
+After cloning, install the required Python dependencies:
+
+```bash
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,10 @@
+numpy
+pandas
+seaborn
+scipy
+requests
+matplotlib
+natsort
+scikit-learn
+beautifulsoup4
+configparser


### PR DESCRIPTION
# Changes Made

Added requirements.txt file with all necessary Python dependencies
Updated README.md with instructions for installing Python dependencies
Added missing documentation for 7-Zip installation, which is a required dependency for extracting npm packages
Included OS-specific installation commands for 7-Zip on macOS, Linux, and Windows

# Why These Changes Are Needed

Previously, the repository lacked a requirements.txt file, making it difficult for new users to set up the development environment. Additionally, the 7-Zip dependency was used internally but not documented, leading to errors when running the tool without it installed.

